### PR TITLE
Added drive link for app icon

### DIFF
--- a/App icon/kaneki-ken260.txt
+++ b/App icon/kaneki-ken260.txt
@@ -1,0 +1,3 @@
+Drive link:
+
+https://drive.google.com/drive/folders/1gHCQ692zDa6pl8_ACzJ_54i6LaqW56pu?usp=sharing


### PR DESCRIPTION
Issue: 52

Added drive link for the app icon.


Here is the drive link:
https://drive.google.com/drive/folders/1gHCQ692zDa6pl8_ACzJ_54i6LaqW56pu?usp=sharing
